### PR TITLE
fix(icons): use calcite assets hosted on CDN

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,6 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "postinstall": "npm run copy",
-    "copy": "ncp ./node_modules/@esri/calcite-components/dist/calcite/assets/ ./public/assets/",
     "lint": "concurrently npm:lint:*",
     "lint:html": "prettier --write \"**/*.html\"",
     "lint:js": "eslint --ext .js,.jsx --fix . && prettier --write \"**/*.js\"",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "./components/App";
+import { setAssetPath } from "@esri/calcite-components/dist/components";
+setAssetPath(`https://unpkg.com/@esri/calcite-components/dist/calcite/assets`);
 
 ReactDOM.render(
   <React.StrictMode>


### PR DESCRIPTION
- Use the jsapi CDN hosted calcite assets
- https://unpkg.com/@esri/calcite-components/dist/calcite/assets