### PR TITLE
feat(info): add styled component for map  info rows

### DIFF
--- a/src/components/maps/BioMapInfo.tsx
+++ b/src/components/maps/BioMapInfo.tsx
@@ -4,29 +4,44 @@ import { CalcitePanel } from "@esri/calcite-components-react";
 import "./BioMap.css";
 import styled from "styled-components";
 
-const Panel = styled.div`
-  width: 50%;
+const InfoContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+`;
+
+const InfoItem = styled.div`
+  flex: 0 44%;
+  margin: 3%;
 `;
 
 export default (): JSX.Element => (
-  <Panel as={CalcitePanel} heading="Shannon-Wiener Index">
-    <div id="info-panel-content">
-      <p className="p-math">
-        `H = &#8212;<span className="span-math">&Sigma;</span>P<sub>i</sub> ln(P<sub>i</sub>)`
-      </p>
-      <p>
-        <b>
-          P<sub>i</sub>
-        </b>{" "}
-        - the proportion of individuals in a species
-        <br />
-        <b>H</b> - the index
-      </p>
-      <p>
-        The <b>Shannon-Wiener Index</b> is a diversity index widely used to compare species
-        diversity. This index is not meant to be a measurement of diversity, but a tool to compare
-        diversity between one or more communities of species.
-      </p>
-    </div>
-  </Panel>
+  <InfoContainer>
+    <InfoItem as={CalcitePanel} heading="Shannon-Wiener Index">
+      <div id="info-panel-content">
+        <p className="p-math">
+          `H = &#8212;<span className="span-math">&Sigma;</span>P<sub>i</sub> ln(P<sub>i</sub>)`
+        </p>
+        <p>
+          <b>
+            P<sub>i</sub>
+          </b>{" "}
+          - the proportion of individuals in a species
+          <br />
+          <b>H</b> - the index
+        </p>
+        <p>
+          The <b>Shannon-Wiener Index</b> is a diversity index widely used to compare species
+          diversity. This index is not meant to be a measurement of diversity, but a tool to compare
+          diversity between one or more communities of species.
+        </p>
+      </div>
+    </InfoItem>
+
+    <InfoItem>
+      blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
+      blah blah blah blah blah blah blah blah blah blah blah blah blah dur dur dur dur dur dur dur
+      dur dur dur dur dur dur dur dur dur dur dur dur dur dur dur dur dur dur dur dur dur dur
+    </InfoItem>
+  </InfoContainer>
 );


### PR DESCRIPTION
- Added `InfoContainer` and  `InfoItem` styled components that can be used to add info above the maps. Use the `src/components/maps/BioMapItem.tsx` file as reference. Add your map item's file to  `src/components/maps/MapDeck.tsx` using the bio one as reference. Lmk if you have any questions or need any changes (more items per row, etc), happy to help.